### PR TITLE
Bump gh actions pin to ubuntu-20.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
 
   docker-build:
     name: Docker Build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -29,7 +29,7 @@ jobs:
 
   tidy:
     name: Docs, Miscellaneous
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     container:
@@ -43,7 +43,7 @@ jobs:
 
   binder:
     name: Notebooks
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     container:
@@ -64,7 +64,7 @@ jobs:
 
   # unit:
   #   name: Unit Tests
-  #   runs-on: ubuntu-16.04
+  #   runs-on: ubuntu-20.04
   #   needs:
   #     - docker-build
   #   strategy:
@@ -88,7 +88,7 @@ jobs:
   #         ctest
   unit:
     name: Unit Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     strategy:
@@ -108,7 +108,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     env:
@@ -130,7 +130,7 @@ jobs:
   # TODO: figure out why codecov errors out
   # coverage:
   #   name: Coverage
-  #   runs-on: ubuntu-16.04
+  #   runs-on: ubuntu-20.04
   #   needs:
   #     - docker-build
   #   container:
@@ -157,7 +157,7 @@ jobs:
 
   microbenchmarks:
     name: Microbenchmarks
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     container:
@@ -175,7 +175,7 @@ jobs:
 
   macrobenchmarks:
     name: Macrobenchmarks
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     container:
@@ -193,7 +193,7 @@ jobs:
 
   docs:
     name: Source, Docs, Demos
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docker-build
     steps:
@@ -202,7 +202,7 @@ jobs:
   # TODO: figure out how to fix npm error
   # docs:
   #   name: Source, Docs, Demos
-  #   runs-on: ubuntu-16.04
+  #   runs-on: ubuntu-20.04
   #   needs:
   #     - docker-build
   #   container:
@@ -219,7 +219,7 @@ jobs:
 
   deploy-pages:
     name: Deploy to GitHub Pages
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     container:
       image: mmore500/conduit:GITHUB_ACTION_${{ github.run_number }}
       env:
@@ -247,7 +247,7 @@ jobs:
 
   deploy-dockerhub:
     name: Deploy to Dockerhub
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     needs:
       - docs
       - unit


### PR DESCRIPTION
Due to ubuntu-16.04 EOL

See https://github.com/actions/virtual-environments/issues/3287