### PR TITLE
Disable git safe directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -291,6 +291,7 @@ RUN \
     && \
   echo "user added and granted permissions to /opt and /home/user"
 
+# git safe directory: https://stackoverflow.com/a/73100228/17332200
 RUN \
   mkdir /context/ \
     && \
@@ -299,6 +300,8 @@ RUN \
   mkdir /__w/ \
     && \
   chown user:user /__w/ \
+    && \
+  git config --global --add safe.directory '*' \
     && \
   echo "/context/ /__w/ directories set up, user granted permissions"
 


### PR DESCRIPTION
Cause of "dubious ownership" error on GH actions deploy